### PR TITLE
Fix flaky

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/model/RestResult.java
+++ b/common/src/main/java/com/alibaba/nacos/common/model/RestResult.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.common.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 
 /**
@@ -27,10 +28,12 @@ public class RestResult<T> implements Serializable {
     
     private static final long serialVersionUID = 6095433538316185017L;
     
+    @JsonProperty(index = 1)
     private int code;
     
     private String message;
     
+    @JsonProperty(index = 2)
     private T data;
     
     public RestResult() {

--- a/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
@@ -36,7 +36,7 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -434,7 +434,7 @@ public class JacksonUtilsTest {
 
     @Test
     public void testToJsonBytes() {
-        HashMap<String, Object> map = new HashMap<String, Object>();
+        LinkedHashMap<String, Object> map = new LinkedHashMap<String, Object>();
         map.put("string", "你好，中国！");
         map.put("integer", 999);
         RestResult<Map<String, Object>> restResult = new RestResult();
@@ -476,10 +476,13 @@ public class JacksonUtilsTest {
     
     static class TestOfAtomicObject {
         
+        @JsonProperty(index = 1)
         public AtomicLong aLong = new AtomicLong(0);
         
+        @JsonProperty(index = 2)
         public AtomicInteger aInteger = new AtomicInteger(1);
         
+        @JsonProperty(index = 3)
         public AtomicBoolean aBoolean = new AtomicBoolean(false);
         
         @Override
@@ -560,10 +563,12 @@ public class JacksonUtilsTest {
     
     static class TestOfGetter {
         
+        @JsonProperty(index = 2)
         public String getKey() {
             return "key";
         }
         
+        @JsonProperty(index = 1)
         public String getValue() {
             return "value";
         }


### PR DESCRIPTION
### **What is the purpose of this PR**

-  This PR fixes three flaky tests inside of JacksonUtilsTest, which are testToJson1(), testToJsonBytes1(), and testToJsonBytes().

### **Reproduce the test failure**

-  Run the test multiple times in the same JVM with different MAVEN random seeds.

### **Expected result:**

-  The tests should run successfully when multiple tests uses different MAVEN random seeds.

### **Actual result:**
   We get the following failures:
-  [ERROR] Failures: JacksonUtilsTest.testToJson1:58 expected:<{"a[Long":0,"aInteger":1],"aBoolean":false}> but was:<{"a[Integer":1,"aLong":0],"aBoolean":false}>
-  [ERROR] Failures: JacksonUtilsTest.testToJsonBytes1:94 arrays first differed at element [3]; expected:<76> but was:<73>
-  [ERROR] Failures: JacksonUtilsTest.testToJsonBytes:446 expected:<{"[code":0,"data":{"string":"你好，中国！","integer":999}]}> but was:<{"[data":{"integer":999,"string":"你好，中国！"},"code":0]}>

### **Why the test fails**

-  Each tests are associated with JacksonUtil method toJson(), which will transform an object into their byte representations, but the method does not grantee de-serialization orders of objects. In addition, testToJsonBytes() assumed the toString order of a hash map, but hash map does not grantee the order of elements. Thus, three tests failed because of their internal element order.

### **Fix**

-  We can fix the problem by setting JacksonProperty index to each objects within static classes, so when toJson() de-serialize the class, the method understand the correct order to run. For the hash maps, we can use a linked hash map that will grantee the insertion order.

